### PR TITLE
Log analysis

### DIFF
--- a/current.opam
+++ b/current.opam
@@ -20,5 +20,6 @@ depends: [
   "duration"
   "prometheus"
   "dune"
+  "re"
   "alcotest-lwt" {with-test}
 ]

--- a/lib/current.ml
+++ b/lib/current.ml
@@ -331,3 +331,4 @@ module Job = Job
 module Process = Process
 module Switch = Switch
 module Pool = Pool
+module Log_matcher = Log_matcher

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -357,3 +357,37 @@ module Db : sig
   val dump_row : Sqlite3.Data.t list Fmt.t
   (** Useful for debugging. *)
 end
+
+module Log_matcher : sig
+  type rule = {
+    pattern : string;
+    report : string;
+    score : int;
+  }
+
+  val analyse_job : Job.t -> string option
+  (** [analyse_job j] scans the logs for [j] looking for known patterns.
+      If it finds any, it returns the report string for the best one, and
+      also logs information about all found patterns. *)
+
+  val add_rule : rule -> unit
+  (** Add a rule that matches log text against the PCRE [rule.pattern].
+      If it matches, the error will be [rule.report]. In [report], "\1" is
+      replaced by the first match group, etc. If multiple rules match, the one
+      with the highest scrore is used. If two rules with the same score match,
+      the first is used. If a rule already exists with the same pattern, it
+      will be replaced. *)
+
+  val remove_rule : string -> (unit, [> `Rule_not_found ]) result
+  (** [remove_rule pattern] removes a rule previously added by [add_rule]. *)
+
+  val list_rules : unit -> rule list
+  (** Get the current set of rules. *)
+
+  (**/**)
+
+  (* For unit-tests: *)
+
+  val drop_all : unit -> unit
+  val analyse_string : ?job:Job.t -> string -> string option
+end

--- a/lib/log_matcher.ml
+++ b/lib/log_matcher.ml
@@ -1,0 +1,154 @@
+type rule = {
+  pattern : string;
+  report : string;
+  score : int;
+}
+
+module Dao = struct
+  type t = {
+    db : Sqlite3.db;
+    load : Sqlite3.stmt;
+    add : Sqlite3.stmt;
+    remove : Sqlite3.stmt;
+    delete_all : Sqlite3.stmt;
+  }
+
+  let v = lazy (
+    let db = Lazy.force Db.v in
+    Sqlite3.exec db "CREATE TABLE IF NOT EXISTS log_regexp ( \
+                     re       TEXT NOT NULL, \
+                     report   TEXT NOT NULL, \
+                     score    INTEGER NOT NULL, \
+                     PRIMARY KEY (re))" |> Db.or_fail ~cmd:"create log_regexp";
+    let load = Sqlite3.prepare db "SELECT re, report, score FROM log_regexp ORDER BY re" in
+    let add = Sqlite3.prepare db "INSERT OR REPLACE INTO log_regexp (re, report, score) VALUES (?, ?, ?)" in
+    let remove = Sqlite3.prepare db "DELETE FROM log_regexp WHERE re = ?" in
+    let delete_all = Sqlite3.prepare db "DELETE FROM log_regexp" in
+    { db; load; add; remove; delete_all }
+  )
+
+  let load () =
+    let t = Lazy.force v in
+    Db.query t.load [] |> List.map @@ function
+    | Sqlite3.Data.[ TEXT pattern; TEXT report; INT score ] -> { pattern; report; score = Int64.to_int score }
+    | row -> Fmt.failwith "load: invalid row %a" Db.dump_row row
+
+  let add { pattern; report; score } =
+    let t = Lazy.force v in
+    Db.exec t.add Sqlite3.Data.[ TEXT pattern; TEXT report; INT (Int64.of_int score) ]
+
+  let remove pattern =
+    let t = Lazy.force v in
+    Db.exec t.remove Sqlite3.Data.[ TEXT pattern ];
+    match Sqlite3.changes t.db with
+    | 0 -> Error `Rule_not_found
+    | 1 -> Ok ()
+    | x -> Fmt.failwith "Multiple rows updated (%d)!" x
+
+  let drop_all () =
+    let t = Lazy.force v in
+    Db.exec t.delete_all []
+end
+
+type test = {
+  re : Re.t;
+  report : string;
+  score : int;
+  mark :Re.Mark.t;
+}
+
+type t = {
+  tests : test list;
+  combined : Re.re;
+}
+
+let re_subst =
+  let (++) a b = Re.seq [a; b] in
+  Re.(compile @@ char '\\' ++ group (rep1 digit))
+
+let t = ref None
+
+let get () =
+  match !t with
+  | Some t -> t
+  | None ->
+    let raw = Dao.load () in
+    let tests =
+      raw |> List.filter_map (fun {pattern; report; score} ->
+          try
+            let mark, re = Re.Pcre.re pattern |> Re.mark in
+            Some { re; report; mark; score }
+          with ex ->
+            Log.err (fun f -> f "Invalid pattern %S: %a" pattern Fmt.exn ex);
+            None
+        )
+    in
+    let combined = Re.no_group (Re.alt (List.map (fun x -> x.re) tests)) |> Re.compile in
+    let v = { tests; combined } in
+    t := Some v;
+    v
+
+let analyse_string ?job log_text =
+  let t = get () in
+  let did_header = ref false in
+  Re.Seq.all t.combined log_text
+  |> Seq.fold_left (fun best group ->
+      (* For each match, find out which test matched. *)
+      let matched = Re.Group.get group 0 in
+      let test = List.find (fun test -> Re.Mark.test group test.mark) t.tests in
+      job |> Option.iter (fun job ->
+          if not !did_header then (
+            Job.log job "Log analysis:";
+            did_header := true
+          );
+          Job.log job ">>> %s (score = %d)" matched test.score);
+      match best with
+      | Some (best_score, _, _) when best_score >= test.score -> best
+      | _ -> Some (test.score, group, test)
+    ) None
+  |> function
+  | None -> None      (* No matches found *)
+  | Some (_score, group, test) ->
+    (* [test] is the best match. Run it again with matching to generate the report. *)
+    let pos, stop = Re.Group.offset group 0 in
+    let group = Re.exec ~pos ~len:(stop - pos) (Re.compile test.re) log_text in
+    let subst g =
+      let r = Re.Group.get g 1 in
+      try Re.Group.get group (int_of_string r)
+      with ex ->
+        Log.err (fun f -> f "Bad group %S in report %S: %a" r test.report Fmt.exn ex);
+        Fmt.strf "Bad group %S in report %S: %a" r test.report Fmt.exn ex
+    in
+    let report = Re.replace ~all:true re_subst ~f:subst test.report in
+    job |> Option.iter (fun job -> Job.log job "%s" report);
+    Some report
+
+let analyse_file ?job log_path =
+  let ch = open_in (Fpath.to_string log_path) in
+  (* re doesn't support streaming, so load the whole log at once. *)
+  let log_text =
+    Fun.protect
+      (fun () -> really_input_string ch (in_channel_length ch))
+      ~finally:(fun () -> close_in ch)
+  in
+  analyse_string ?job log_text
+
+let analyse_job job =
+  match Job.log_path (Job.id job) with
+  | Error `Msg e -> Fmt.failwith "Job log missing! %s" e
+  | Ok log_path -> analyse_file ~job log_path
+
+let add_rule rule =
+  ignore (Re.Pcre.re rule.pattern);  (* Check it compiles *)
+  Dao.add rule;
+  t := None
+
+let remove_rule pattern =
+  Dao.remove pattern |> Stdlib.Result.map (fun () -> t := None)
+
+let list_rules () =
+  Dao.load ()
+
+let drop_all () =
+  Dao.drop_all ();
+  t := None

--- a/lib_cache/current_cache.ml
+++ b/lib_cache/current_cache.ml
@@ -219,11 +219,13 @@ module Output(Op : S.PUBLISHER) = struct
                 in
                 let outcome =
                   if Current.Switch.is_on op.switch then (
-                    begin match outcome with
-                      | Ok _ -> Job.log job "Job succeeded"
-                      | Error (`Msg m) -> Job.log job "Job failed: %s" m;
-                    end;
-                    outcome
+                    match outcome with
+                      | Ok _ -> Job.log job "Job succeeded"; outcome
+                      | Error (`Msg m) ->
+                        Job.log job "Job failed: %s" m;
+                        match Current.Log_matcher.analyse_job job with
+                        | None -> outcome
+                        | Some e -> Error (`Msg e)
                   ) else Error (`Msg "Cancelled")
                 in
                 output.mtime <- !Job.timestamp ();

--- a/lib_cache/dune
+++ b/lib_cache/dune
@@ -1,4 +1,4 @@
 (library
   (public_name current.cache)
   (name current_cache)
-  (libraries current lwt lwt.unix duration))
+  (libraries current lwt lwt.unix duration re))

--- a/lib_web/current_web.ml
+++ b/lib_web/current_web.ml
@@ -144,6 +144,10 @@ let handle_request ~engine ~webhooks _conn request body =
     | `GET, ["query"] ->
       let body = Query.render uri in
       Server.respond_string ~status:`OK ~body ()
+    | `GET, ["log-rules"] ->
+      Log_rules.render ()
+    | `POST, ["log-rules"] ->
+      Cohttp_lwt.Body.to_string body >>= Log_rules.handle_post
     | `GET, ["metrics"] ->
       let data = Prometheus.CollectorRegistry.(collect default) in
       let body = Fmt.to_to_string Prometheus_app.TextFormat_0_0_4.output data in

--- a/lib_web/log_rules.ml
+++ b/lib_web/log_rules.ml
@@ -1,0 +1,160 @@
+open Tyxml.Html
+
+module Server = Cohttp_lwt_unix.Server
+module LM = Current.Log_matcher
+
+let render_row { LM.pattern; report; score } =
+  tr [
+    td [ txt pattern ];
+    td [ txt report ];
+    td [ txt (string_of_int score) ];
+  ]
+
+let get_recent_jobs = lazy (
+  let db = Lazy.force Current.Db.v in
+  Sqlite3.prepare db "SELECT job_id FROM cache ORDER BY finished DESC LIMIT ?"
+)
+
+let dump_groups f groups =
+  if Array.length groups = 0 then Fmt.string f "Missing match!"
+  else (
+    Fmt.pf f "%s" groups.(0);
+    for i = 1 to Array.length groups - 1 do
+      Fmt.pf f "@.\\%d : %s" i groups.(i);
+    done
+  )
+
+let test_pattern pattern =
+  let re = Re.Pcre.re pattern |> Re.compile in
+  let recent_jobs = Lazy.force get_recent_jobs in
+  let jobs = Current.Db.query recent_jobs Sqlite3.Data.[ INT 1000L ] in
+  let n_jobs = List.length jobs in
+  let results = jobs |> List.filter_map (function
+      | Sqlite3.Data.[ TEXT job_id ] ->
+        begin match Current.Job.log_path job_id with
+          | Ok path ->
+            let log_data =
+              let ch = open_in_bin (Fpath.to_string path) in
+              Fun.protect
+                (fun () -> really_input_string ch (in_channel_length ch))
+                ~finally:(fun () -> close_in ch)
+            in
+            Re.exec_opt re log_data |> Option.map (fun g ->
+                let text = Fmt.strf "@[<v>%a@]" dump_groups (Re.Group.all g) in
+                job_id, text
+              )
+          | Error _ -> None
+        end
+      | row -> Fmt.failwith "Bad row from get_recent_jobs: %a" Current.Db.dump_row row
+    )
+  in
+  let open Tyxml.Html in
+  match results with
+  | [] -> [p [txt (Fmt.strf "New pattern doesn't match anything in last %d jobs" n_jobs)]]
+  | results ->
+    [
+      p [txt (Fmt.strf "%d matches in last %d jobs:" (List.length results) n_jobs)];
+      table ~a:[a_class ["table"]]
+        ~thead:(thead [
+            tr [
+              th [txt "Job"];
+              th [txt "Match"];
+            ]
+          ])
+        (results |> List.map @@ fun (job_id, text) ->
+         let job = Fmt.strf "/job/%s" job_id in
+         tr [
+           td [ a ~a:[a_href job] [txt job_id] ];
+           td [pre [txt text]]
+         ]
+        )
+    ]
+
+let pattern_hints =
+  let open Tyxml.Html in
+  p [
+    txt "In patterns, use ";
+    code [txt "()"]; txt " for match groups, ";
+    code [txt "?+*"]; txt " to match zero-or-one times, one-or-more times, or zero-or-more times, and ";
+    code [txt "[\\n]"]; txt " to match newlines."
+  ]
+
+let render ?msg ?test ?(pattern="") ?(report="") ?(score="") () =
+  let rules = Current.Log_matcher.list_rules () in
+  let message = match msg with
+    | None -> []
+    | Some msg -> [p [txt msg]]
+  in
+  let test_results = match test with
+    | None -> []
+    | Some p -> test_pattern p
+  in
+  let body =
+    Main.template (message @ [
+        form ~a:[a_action "/log-rules"; a_method `Post] [
+          table ~a:[a_class ["table"; "log-rules"]]
+            ~thead:(thead [
+                tr [
+                  th [txt "Pattern (PCRE)"];
+                  th [txt "Report"];
+                  th [txt "Score"];
+                ]
+              ])
+            (List.map render_row rules @
+             [
+               tr [
+                 td [ input ~a:[a_input_type `Text; a_name "pattern"; a_value pattern] () ];
+                 td [ input ~a:[a_input_type `Text; a_name "report"; a_value report] () ];
+                 td ~a:[a_class ["score"]] [ input ~a:[a_input_type `Text; a_name "score"; a_value score] () ];
+               ]
+             ]
+            );
+          input ~a:[a_input_type `Submit; a_name "test"; a_value "Test pattern"] ();
+          input ~a:[a_input_type `Submit; a_name "add"; a_value "Add rule"] ();
+          input ~a:[a_input_type `Submit; a_name "remove"; a_value "Remove rule"] ();
+        ]
+      ] @ [pattern_hints] @ test_results)
+  in
+  Server.respond_string ~status:`OK ~body ()
+
+let handle_post data =
+  let data = Uri.query_of_encoded data in
+  let pattern = List.assoc_opt "pattern" data |> Option.value ~default:[] in
+  let report = List.assoc_opt "report" data |> Option.value ~default:[] in
+  let score = List.assoc_opt "score" data |> Option.value ~default:[] in
+  if List.mem_assoc "remove" data then (
+    match pattern with
+    | [""] -> Server.respond_error ~body:"Pattern can't be empty" ()
+    | [pattern] ->
+        begin match LM.remove_rule pattern with
+          | Ok () -> render ~msg:"Rule removed" ()
+          | Error `Rule_not_found -> render ~msg:"Rule not found" ~pattern ()
+        end
+    | _ ->
+      Server.respond_error ~body:"Bad form submission" ()
+  ) else if List.mem_assoc "add" data then (
+    match pattern, report, score with
+    | [""], _, _ -> Server.respond_error ~body:"Pattern can't be empty" ()
+    | _, [""], _ -> Server.respond_error ~body:"Report can't be empty" ()
+    | _, _, [""] -> Server.respond_error ~body:"Score can't be empty" ()
+    | [pattern], [report], [score] ->
+      begin match Re.Pcre.re pattern with
+        | exception _ -> Server.respond_error ~body:"Invalid PCRE-format pattern" ()
+        | _ ->
+          begin match Astring.String.to_int score with
+            | Some score -> LM.add_rule { LM.pattern; report; score }; render ~msg:"Rule added" ()
+            | None -> Server.respond_error ~body:"Score must be an integer" ()
+          end
+      end
+    | _ ->
+      Server.respond_error ~body:"Bad form submission" ()
+  ) else if List.mem_assoc "test" data then (
+    match pattern, report, score with
+    | [""], _, _ -> Server.respond_error ~body:"Pattern can't be empty" ()
+    | [pattern], [report], [score] -> render ~test:pattern ~pattern ~report ~score ()
+    | _ -> Server.respond_error ~body:"Bad form submission" ()
+  ) else (
+    Server.respond_error ~body:"Bad form submission" ()
+  )
+
+let render () = render ()

--- a/lib_web/log_rules.mli
+++ b/lib_web/log_rules.mli
@@ -1,0 +1,2 @@
+val render : unit -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+val handle_post : string -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t

--- a/lib_web/main.ml
+++ b/lib_web/main.ml
@@ -21,6 +21,7 @@ let template contents =
               li [a ~a:[a_href "/"] [txt "OCurrent"]];
               li [a ~a:[a_href "/"] [txt "Home"]];
               li [a ~a:[a_href "/query"] [txt "Query"]];
+              li [a ~a:[a_href "/log-rules"] [txt "Log analysis"]];
             ]
           ];
           div ~a:[a_id "main"] contents

--- a/lib_web/style.ml
+++ b/lib_web/style.ml
@@ -61,6 +61,23 @@ let css = {|
   form {
     padding: 0.2em;
   }
+
+  table.log-rules {
+    width: 100%;
+  }
+
+  table td input {
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  table.log-rules td.score {
+    width: 4em;
+  }
+
+  table pre {
+    margin: 0;
+  }
 |} ^ Current_ansi.css
 
 let get () =

--- a/test/test.ml
+++ b/test/test.ml
@@ -126,4 +126,5 @@ let () =
     "cache", Test_cache.tests;
     "monitor", Test_monitor.tests;
     "job", Test_job.tests;
+    "log_matcher", Test_log_matcher.tests;
   ]

--- a/test/test_log_matcher.ml
+++ b/test/test_log_matcher.ml
@@ -1,0 +1,42 @@
+module M = Current.Log_matcher
+
+let pp_rule f { M.pattern; report; score } =
+  Fmt.pf f "%s/%s/%d" pattern report score
+
+let rule = Alcotest.testable pp_rule (=)
+
+let no_rule =
+  let pp_no_rule f `Rule_not_found = Fmt.string f "Rule_not_found" in
+  Alcotest.testable pp_no_rule (=)
+
+let rule1 = { M.pattern = "Make exited with status (\\d+)"; report = "exit(\\1)"; score = 5 }
+let rule2 = { M.pattern = "ENOSPACE"; report = "Out of disk space"; score = 10 }
+
+let basic () =
+  M.drop_all ();
+  Alcotest.(check (option string)) "No rules" None @@ M.analyse_string "Make exited with status 2";
+  M.add_rule rule1;
+  Alcotest.(check (option string)) "One rule" (Some "exit(2)") @@ M.analyse_string "Make exited with status 2";
+  M.add_rule rule2;
+  Alcotest.(check (option string)) "Best first" (Some "Out of disk space") @@ M.analyse_string
+    "Got ENOSPACE\n\
+     Make exited with status 2";
+  Alcotest.(check (option string)) "Best second" (Some "Out of disk space") @@ M.analyse_string
+    "Make exited with status 2\n\
+     Got ENOSPACE";
+  M.add_rule { rule1 with score = 20 };
+  Alcotest.(check (option string)) "Best now first" (Some "exit(2)") @@ M.analyse_string
+    "Make exited with status 2\n\
+     Got ENOSPACE";
+  M.add_rule rule1;
+  Alcotest.(check (list rule)) "List rules" [rule2; rule1] @@ M.list_rules ();
+  Alcotest.(check (result unit no_rule)) "Remove rule" (Ok ()) @@ M.remove_rule rule2.M.pattern;
+  Alcotest.(check (result unit no_rule)) "Remove rule twice" (Error `Rule_not_found) @@ M.remove_rule rule2.M.pattern;
+  Alcotest.(check (option string)) "One again" (Some "exit(2)") @@ M.analyse_string
+    "Make exited with status 2\n\
+     Got ENOSPACE"
+
+let tests =
+  [
+    Alcotest.test_case "basic" `Quick basic;
+  ]

--- a/test/test_log_matcher.mli
+++ b/test/test_log_matcher.mli
@@ -1,0 +1,1 @@
+val tests : unit Alcotest.test_case list


### PR DESCRIPTION
OCurrent can now be configured with a list of log patterns and some replacement text to report if the pattern is found. e.g.

  Pattern: `ERROR: unsatisfiable constraints:.*[\n].* ([^ ]+) \(missing\)`
  Report: `Missing Alpine package \1`

After each build, it finds the highest-scoring match and then uses the template string as the error, after substituting any group references.

There is a new page in the admin web UI for editing the list of rules, and for testing new patterns against the last 1000 jobs.