### PR TITLE
Add plugin for linting via Dune

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,4 @@
+version = 0.11.0
+profile = conventional
+parse-docstrings = true
+disable = true

--- a/.ocamlformat-enable
+++ b/.ocamlformat-enable
@@ -1,0 +1,2 @@
+plugins/lint/current_lint.ml
+plugins/lint/current_lint.mli

--- a/current_lint.opam
+++ b/current_lint.opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "OCurrent Linting plugin"
+maintainer: "me@craigfe.io"
+authors: "me@craigfe.io"
+homepage: "https://github.com/ocaml-ci/current"
+bug-reports: "https://github.com/ocaml-ci/current/issues"
+dev-repo: "git+https://github.com/ocaml-ci/current.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "current" {= version}
+  "current_git" {= version}
+  "current_docker" {= version}
+  "fmt"
+  "ppx_deriving"
+  "lwt"
+  "dockerfile"
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "yojson"
+  "dune"
+]

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
 (lang dune 1.9)
+(using fmt 1.0)

--- a/lib_web/current_web.ml
+++ b/lib_web/current_web.ml
@@ -134,6 +134,11 @@ let handle_request ~engine ~webhooks _conn request body =
     | `GET, ["pipeline.svg"] ->
       begin
         let state = Current.Engine.state engine in
+        let () = Logs.debug (fun m ->
+          let a = state.Current.Engine.analysis in
+          m "rendered pipeline: \n%a" Current.Analysis.pp a
+        )
+        in
         render_svg state.Current.Engine.analysis >>= function
         | Ok body ->
           let headers = Cohttp.Header.init_with "Content-Type" "image/svg+xml" in

--- a/plugins/lint/current_lint.ml
+++ b/plugins/lint/current_lint.ml
@@ -1,0 +1,85 @@
+open Current.Syntax
+module Docker = Current_docker.Default
+
+let src = Logs.Src.create "current_fmt" ~doc:"Current pipelines for linting"
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+let option_map f = function Some x -> Some (f x) | None -> None
+
+let version_from_string =
+  let re =
+    Re.(
+      seq
+        [
+          start;
+          rep space;
+          str "version";
+          rep space;
+          char '=';
+          rep space;
+          group (rep1 @@ diff graph (set "#"));
+          rep space;
+          eol;
+        ]
+      |> compile)
+  in
+  fun path -> Re.exec_opt re path |> option_map (fun g -> Re.Group.get g 1)
+
+let version_from_file path =
+  let ( let+ ) = Lwt.Infix.( >>= ) in
+  let ( let* ) = Lwt.Infix.( >|= ) in
+  if not (Sys.file_exists path) then
+    let () = Logs.info (fun m -> m "No .ocamlformat file found") in
+    Lwt.return (Ok None)
+  else
+    let+ channel = Lwt_io.open_file ~mode:Lwt_io.input path in
+    let* versions =
+      Lwt_io.read_lines channel
+      |> Lwt_stream.filter_map version_from_string
+      |> Lwt_stream.to_list
+    in
+    match versions with
+    | [ v ] ->
+        let () =
+          Logs.info (fun m -> m "Found OCamlformat version '%s' in dotfile" v)
+        in
+        Ok (Some v)
+    | _ -> Error (`Msg "Unable to parse .ocamlformat file")
+
+let get_ocamlformat_version ~src =
+  Current.component "Infer OCamlformat\nversion"
+  |> let> src = src in
+     let switch = Current.Switch.create ~label:"blah" () in
+     let config = Current.Config.v () in
+     let job = Current.Job.create ~switch ~config ~label:"blah" () in
+     Current.Input.const
+       (Lwt_main.run
+          (Current_git.with_checkout ~switch ~job src (fun root ->
+               let dotfile = Fpath.(to_string (root / ".ocamlformat")) in
+               version_from_file dotfile))
+        |> function
+        | Ok (Some t) -> t
+        | Ok None -> "0.11.0"
+        | Error (`Msg e) -> failwith e)
+
+let format_dockerfile ~base ~ocamlformat_version =
+  let open Dockerfile in
+  from (Docker.Image.hash base)
+  @@ run "git -C /home/opam/opam-repository pull"
+  @@ run "opam depext ocamlformat=%s" ocamlformat_version
+  @@ run "opam install ocamlformat=%s" ocamlformat_version
+
+let v_from_opam ?ocamlformat_version ~base ~src =
+  let dockerfile =
+    let+ ocamlformat_version =
+      match ocamlformat_version with
+      | Some v -> Current.return ~label:("version " ^ v) v
+      | None -> get_ocamlformat_version ~src
+    and+ base = base in
+    format_dockerfile ~base ~ocamlformat_version
+  in
+  let img =
+    Docker.build ~label:"OCamlformat" ~pull:false ~dockerfile (`Git src)
+  in
+  Docker.run ~label:"lint" img ~args:[ "dune"; "build"; "@fmt" ]

--- a/plugins/lint/current_lint.mli
+++ b/plugins/lint/current_lint.mli
@@ -1,0 +1,10 @@
+module Docker = Current_docker.Default
+
+val v_from_opam :
+  ?ocamlformat_version:string ->
+  base:Docker.Image.t Current.t ->
+  src:Current_git.Commit.t Current.t ->
+  unit Current.t
+(** [v ~base ~src] runs a Dune linting check on [src] via the base image [base]
+    with OPAM installed. If [ocamlformat_version] is not passed, it will be
+    inferred from the [.ocamlformat] file in the root of [src]. *)

--- a/plugins/lint/dune
+++ b/plugins/lint/dune
@@ -1,0 +1,4 @@
+(library
+ (public_name current_lint)
+ (name current_lint)
+ (libraries current.cache current_docker re))


### PR DESCRIPTION
This supplies a linting pipeline stage via the `dune build @fmt` target, which will pre-install the correct version of OCamlformat necessary to run the format:

![image](https://user-images.githubusercontent.com/26125912/67304991-f8825780-f4f4-11e9-93be-bcc2e765e5dd.png)

Currently untested.