### PR TITLE
Add ?hidden option to Current.catch

### DIFF
--- a/lib_term/current_term.ml
+++ b/lib_term/current_term.ml
@@ -71,15 +71,11 @@ module Make (Input : S.INPUT) = struct
     let t = t ctx in
     make (An.state ~env t.md) (Dyn.state t.fn)
 
-  let catch t =
+  let catch ?(hidden=false) t =
     cache @@ fun ~env ctx ->
     let t = t ctx in
-    make (An.catch ~env t.md) (Dyn.catch t.fn)
-
-  let catch_hidden t =
-    cache @@ fun ~env:_ ctx ->
-    let t = t ctx in
-    make t.md (Dyn.catch t.fn)
+    let an = if hidden then t.md else An.catch ~env t.md in
+    make an (Dyn.catch t.fn)
 
   let of_output x =
     cache @@ fun ~env _ctx ->
@@ -175,7 +171,7 @@ module Make (Input : S.INPUT) = struct
     let rec aux = function
       | [] -> return (Ok ())
       | (l, x) :: xs ->
-        let+ x = catch_hidden x
+        let+ x = catch x ~hidden:true
         and+ xs = aux xs in
         match x with
         | Ok () -> xs

--- a/lib_term/s.ml
+++ b/lib_term/s.ml
@@ -68,10 +68,11 @@ module type TERM = sig
   val state : 'a t -> ('a, [`Active of Output.active | `Msg of string]) result t
   (** [state t] always immediately returns a successful result giving the current state of [t]. *)
 
-  val catch : 'a t -> 'a or_error t
+  val catch : ?hidden:bool -> 'a t -> 'a or_error t
   (** [catch t] successfully returns [Ok x] if [t] evaluates successfully to [x],
       or successfully returns [Error e] if [t] fails with error [e].
-      If [t] is active then [catch t] will be active too. *)
+      If [t] is active then [catch t] will be active too.
+      @param hidden If [true], don't show a separate node for this on the diagrams. *)
 
   val ignore_value : 'a t -> unit t
   (** [ignore_value x] is [map ignore x]. *)


### PR DESCRIPTION
This is useful for building other combinators like `Current.all`, where it's already clear that errors are being handled.