### PR TITLE
Add Current.option_map

### DIFF
--- a/lib_term/analysis.mli
+++ b/lib_term/analysis.mli
@@ -20,19 +20,21 @@ module Make (Job : sig type id end) : sig
      passed to a [bind]. All static values created within this environment get an
      implicit dependency on [b]. *)
 
-  val return     : env:env -> string option -> t
-  val fail       : env:env -> string -> t
-  val map_input  : env:env -> t -> (string, [`Blocked | `Empty_list]) result -> t
-  val map_failed : env:env -> t -> string -> t
-  val state      : env:env -> t -> t
-  val catch      : env:env -> t -> t
-  val active     : env:env -> Output.active -> t
-  val of_output  : env:env -> _ Output.t -> t
-  val pair       : env:env -> t -> t -> t
-  val bind       : env:env -> ?info:string -> t -> state -> t
-  val bind_input : env:env -> info:string -> t -> state -> t
-  val list_map   : env:env -> f:t -> t -> t
-  val gate       : env:env -> on:t -> t -> t
+  val return       : env:env -> string option -> t
+  val fail         : env:env -> string -> t
+  val map_input    : env:env -> t -> (string, [`Blocked | `Empty_list]) result -> t
+  val map_failed   : env:env -> t -> string -> t
+  val option_input : env:env -> t -> [`Blocked | `Selected | `Not_selected] -> t
+  val state        : env:env -> t -> t
+  val catch        : env:env -> t -> t
+  val active       : env:env -> Output.active -> t
+  val of_output    : env:env -> _ Output.t -> t
+  val pair         : env:env -> t -> t -> t
+  val bind         : env:env -> ?info:string -> t -> state -> t
+  val bind_input   : env:env -> info:string -> t -> state -> t
+  val list_map     : env:env -> f:t -> t -> t
+  val option_map   : env:env -> f:t -> t -> t
+  val gate         : env:env -> on:t -> t -> t
 
   val booting : t
 

--- a/lib_term/dot.mli
+++ b/lib_term/dot.mli
@@ -2,6 +2,7 @@
 
 val node : Format.formatter -> ?style:string -> ?shape:string -> ?bg:string -> ?url:string -> ?tooltip:string -> int -> string -> unit
 val edge : Format.formatter -> ?style:string -> ?color:string -> int -> int -> unit
+val pp_option : (string * string) Fmt.t
 
 val begin_cluster : Format.formatter -> int -> unit
 val end_cluster : Format.formatter -> unit

--- a/lib_term/s.ml
+++ b/lib_term/s.ml
@@ -107,6 +107,10 @@ module type TERM = sig
   (** [list_seq x] evaluates to a list containing the results of evaluating
       each element in [x], once all elements of [x] have successfully completed. *)
 
+  val option_map : ('a t -> 'b t) -> 'a option t -> 'b option t
+  (** [option_map f x] is a term that evaluates to [Some (f y)] if [x]
+      evaluates to [Some y], or to [None] otherwise. *)
+
   val option_seq : 'a t option -> 'a option t
   (** [option_seq None] is [Current.return None] and
       [option_seq (Some x)] is [Current.map some x].

--- a/test/dune
+++ b/test/dune
@@ -15,6 +15,7 @@
    v4.1.dot v4.2.dot v4.3.dot
    v5.1.dot v5.2.dot v5.3.dot
    v5n.1.dot v5n.2.dot v5n.3.dot
+   v6.1.dot v6.2.dot
  )
  (action  (run ./test.exe)))
 
@@ -30,4 +31,5 @@
    (diff expected/v4.1.dot v4.1.dot) (diff expected/v4.2.dot v4.2.dot) (diff expected/v4.3.dot v4.3.dot)
    (diff expected/v5.1.dot v5.1.dot) (diff expected/v5.2.dot v5.2.dot) (diff expected/v5.3.dot v5.3.dot)
    (diff expected/v5n.1.dot v5n.1.dot) (diff expected/v5n.2.dot v5n.2.dot) (diff expected/v5n.3.dot v5n.3.dot)
+   (diff expected/v6.1.dot v6.1.dot) (diff expected/v6.2.dot v6.2.dot)
  )))

--- a/test/expected/v6.1.dot
+++ b/test/expected/v6.1.dot
@@ -1,0 +1,13 @@
+digraph pipeline {
+  node [shape="box"]
+  rankdir=LR
+  n3 [label="head",fillcolor="#90ee90",style="filled"]
+  n2 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n1 [label="analyse",fillcolor="#d3d3d3",style="filled"]
+  subgraph cluster_0 {
+  style="dotted"n4 [label="lint",fillcolor="#d3d3d3",style="filled"]
+  }
+  n1 -> n4
+  n2 -> n1
+  n3 -> n2
+  }

--- a/test/expected/v6.2.dot
+++ b/test/expected/v6.2.dot
@@ -1,0 +1,13 @@
+digraph pipeline {
+  node [shape="box"]
+  rankdir=LR
+  n4 [label="head",fillcolor="#90ee90",style="filled"]
+  n3 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n2 [label="analyse",fillcolor="#90ee90",style="filled"]
+  subgraph cluster_0 {
+  style="dotted"n6 [label="lint",fillcolor="#90ee90",style="filled"]
+  }
+  n2 -> n6
+  n3 -> n2
+  n4 -> n3
+  }


### PR DESCRIPTION
On the diagrams, this is shown as a dotted box, indicating that the sub-pipeline can be grey even though the input is ready.

This is a bit simpler than using a list: we don't need to label the items (because there is only even one) and the caller doesn't have to worry about getting multiple items back.

/cc @CraigFe 