### PR TITLE
Autogenerate dune rules for the pipeline expect tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ test:
 	dune build @check
 	if dune runtest --no-buffer; then make svgs; else make svgs; exit 1; fi
 
+test-force:
+	rm _build/default/test/*.dot
+	dune runtest --no-buffer -j 1
+
 svg:
 	mkdir svg
 

--- a/test/dune
+++ b/test/dune
@@ -1,37 +1,23 @@
 (executables
-  (names test test_monitor test_cache)
+  (names gen_dune_rules test test_monitor test_cache)
   (libraries current fmt fmt.tty logs.fmt bos lwt.unix alcotest-lwt
              current_fs
              current_docker_test
              current_git_test
              current_opam_test))
 
+(include dune.inc)
+
 (rule
- (targets
-   v1.1.dot v1.2.dot v1.3.dot
-   v1c.1.dot v1c.2.dot v1c.3.dot
-   v2.1.dot v2.2.dot v2.3.dot v2.4.dot
-   v3.1.dot v3.2.dot v3.3.dot
-   v4.1.dot v4.2.dot v4.3.dot
-   v5.1.dot v5.2.dot v5.3.dot
-   v5n.1.dot v5n.2.dot v5n.3.dot
-   option-some.1.dot option-some.2.dot
-   option-none.1.dot option-none.2.dot
- )
- (action  (run ./test.exe)))
+ (targets dune.gen)
+ (deps
+  (source_tree .))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./gen_dune_rules.exe))))
 
 (alias
  (name runtest)
- (package current)
  (action
-  (progn
-   (diff expected/v1.1.dot v1.1.dot) (diff expected/v1.2.dot v1.2.dot) (diff expected/v1.3.dot v1.3.dot)
-   (diff expected/v1c.1.dot v1c.1.dot) (diff expected/v1c.2.dot v1c.2.dot) (diff expected/v1c.3.dot v1c.3.dot)
-   (diff expected/v2.1.dot v2.1.dot) (diff expected/v2.2.dot v2.2.dot) (diff expected/v2.3.dot v2.3.dot) (diff expected/v2.4.dot v2.4.dot)
-   (diff expected/v3.1.dot v3.1.dot) (diff expected/v3.2.dot v3.2.dot) (diff expected/v3.3.dot v3.3.dot)
-   (diff expected/v4.1.dot v4.1.dot) (diff expected/v4.2.dot v4.2.dot) (diff expected/v4.3.dot v4.3.dot)
-   (diff expected/v5.1.dot v5.1.dot) (diff expected/v5.2.dot v5.2.dot) (diff expected/v5.3.dot v5.3.dot)
-   (diff expected/v5n.1.dot v5n.1.dot) (diff expected/v5n.2.dot v5n.2.dot) (diff expected/v5n.3.dot v5n.3.dot)
-   (diff expected/option-some.1.dot option-some.1.dot) (diff expected/option-some.2.dot option-some.2.dot)
-   (diff expected/option-none.1.dot option-none.1.dot) (diff expected/option-none.2.dot option-none.2.dot)
- )))
+  (diff dune.inc dune.gen)))

--- a/test/dune
+++ b/test/dune
@@ -1,10 +1,16 @@
 (executables
-  (names gen_dune_rules test test_monitor test_cache)
+  (names test test_monitor test_cache)
+  (modules test test_monitor test_cache test_job test_log_matcher driver)
   (libraries current fmt fmt.tty logs.fmt bos lwt.unix alcotest-lwt
              current_fs
              current_docker_test
              current_git_test
              current_opam_test))
+
+(executable
+ (name gen_dune_rules)
+ (modules gen_dune_rules)
+ (libraries fmt fpath))
 
 (include dune.inc)
 

--- a/test/dune.inc
+++ b/test/dune.inc
@@ -1,0 +1,158 @@
+(rule
+ (targets option-none.1.dot
+          option-none.2.dot
+          option-some.1.dot
+          option-some.2.dot
+          v1.1.dot
+          v1.2.dot
+          v1.3.dot
+          v1c.1.dot
+          v1c.2.dot
+          v1c.3.dot
+          v2.1.dot
+          v2.2.dot
+          v2.3.dot
+          v2.4.dot
+          v3.1.dot
+          v3.2.dot
+          v3.3.dot
+          v4.1.dot
+          v4.2.dot
+          v4.3.dot
+          v5.1.dot
+          v5.2.dot
+          v5.3.dot
+          v5n.1.dot
+          v5n.2.dot
+          v5n.3.dot)
+ (action (run ./test.exe)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/option-none.1.dot option-none.1.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/option-none.2.dot option-none.2.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/option-some.1.dot option-some.1.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/option-some.2.dot option-some.2.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v1.1.dot v1.1.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v1.2.dot v1.2.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v1.3.dot v1.3.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v1c.1.dot v1c.1.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v1c.2.dot v1c.2.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v1c.3.dot v1c.3.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v2.1.dot v2.1.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v2.2.dot v2.2.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v2.3.dot v2.3.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v2.4.dot v2.4.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v3.1.dot v3.1.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v3.2.dot v3.2.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v3.3.dot v3.3.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v4.1.dot v4.1.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v4.2.dot v4.2.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v4.3.dot v4.3.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v5.1.dot v5.1.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v5.2.dot v5.2.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v5.3.dot v5.3.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v5n.1.dot v5n.1.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v5n.2.dot v5n.2.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/v5n.3.dot v5n.3.dot)))

--- a/test/gen_dune_rules.ml
+++ b/test/gen_dune_rules.ml
@@ -1,0 +1,31 @@
+let is_testcase name =
+  Fpath.(has_ext "dot" (v name))
+
+let pp_targets ppf filenames =
+  Fmt.pf ppf
+    {|(@[<v>rule@
+(targets %a)
+ (action (run ./test.exe)@]))
+
+|}
+    Fmt.(vbox (list ~sep:cut string)) filenames
+
+let pp_runtest ppf filename =
+  Fmt.pf ppf
+    {|(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/%s %s)))
+|}
+    filename filename
+
+let pp_duneinc =
+  Fmt.(pp_targets ++ list ~sep:cut pp_runtest)
+
+let () =
+  Sys.readdir "expected"
+  |> Array.to_list
+  |> List.sort String.compare
+  |> List.filter is_testcase
+  |> Fmt.(pp_duneinc ++ flush) Fmt.stdout
+


### PR DESCRIPTION
- any `test/expected/*.dot` files cause a corresponding dune diff rule to be generated automatically 
 - these diff rules are independently executable, so it's no longer necessary to repeatedly `dune runtest --autopromote` once per changed test-case

Causes `dune runtest --force` not to work (it re-runs the expected output diffs, but not the test-suite itself). I have added a `make test-force` target to recover the old behaviour.

Thanks to @NathanReb and @emillon for their assistance with Dune.