### PR TITLE
Improve queuing

### DIFF
--- a/current.opam
+++ b/current.opam
@@ -21,5 +21,6 @@ depends: [
   "prometheus"
   "dune"
   "re"
+  "lwt-dllist"
   "alcotest-lwt" {with-test}
 ]

--- a/lib/current.ml
+++ b/lib/current.ml
@@ -189,7 +189,7 @@ module Engine = struct
       trace !last_result >>= fun () ->
       Log.debug (fun f -> f "Waiting for inputs to change...");
       Lwt.choose (filter_map (fun w -> w.changed) watches) >>= fun () ->
-      aux ()
+      Lwt.pause () >>= aux
     in
     let thread =
       (* The pause lets us start the web-server before the first evaluation,

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,6 @@
 (library
   (public_name current)
-  (libraries current_term lwt cmdliner sqlite3 lwt.unix prometheus duration)
+  (libraries current_term lwt cmdliner sqlite3 lwt.unix prometheus duration lwt-dllist)
   (preprocess (per_module
                 ((pps ppx_deriving.std) level)
               )))

--- a/test/test_job.ml
+++ b/test/test_job.ml
@@ -92,7 +92,7 @@ let pool_cancel _switch () =
   let s1 = Job.start ~pool ~level:Current.Level.Harmless job1 in
   Alcotest.(check lwt_state) "Job queued" Lwt.Sleep (Lwt.state s1);
   Current.Switch.turn_off sw1 @@ Error (`Msg "Cancel") >|= fun () ->
-  Alcotest.(check lwt_state) "Job cancelled" Lwt.(Fail Canceled) (Lwt.state s1)
+  Alcotest.(check lwt_state) "Job cancelled" (Lwt.Fail (Failure "Cancelled waiting for resource from pool \"test\"")) (Lwt.state s1)
 
 let tests =
   [


### PR DESCRIPTION
- Add a `Lwt.pause` after each evaluation. This way, if lots of things are happening then we batch them up, making the service more responsive.

- Improve pool queuing. The qlen metric didn't get decremented if the operation was cancelled,
and every event woke up everything, which was inefficient. Replace `Lwt.cancel` with a switch and a queue.