### PR TITLE
Fix job cancellation

### DIFF
--- a/lib/pool.ml
+++ b/lib/pool.ml
@@ -50,10 +50,10 @@ let check t =
       Lwt.wakeup_later waiter `Use
   )
 
-let get ~switch t =
+let get ~on_cancel ~switch t =
   let ready, set_ready = Lwt.wait () in
   let node = Lwt_dllist.add_r set_ready t.queue in
-  Switch.add_hook_or_exec switch (fun _ex ->
+  on_cancel (fun _ ->
       Lwt_dllist.remove node;
       if Lwt.is_sleeping ready then Lwt.wakeup_later set_ready `Cancel;
       Lwt.return_unit

--- a/lib/pool.mli
+++ b/lib/pool.mli
@@ -2,8 +2,8 @@ type t
 
 val create : label:string -> int -> t
 
-val get : switch:Switch.t -> t -> unit Lwt.t
-(** [get ~switch t] waits for a resource and then returns.
+val get : on_cancel:((string -> unit Lwt.t) -> unit Lwt.t) -> switch:Switch.t -> t -> unit Lwt.t
+(** [get ~on_cancel ~switch t] waits for a resource and then returns.
     The resource will be returned to the pool when [switch] is turned off. *)
 
 val pp : t Fmt.t

--- a/lib/process.mli
+++ b/lib/process.mli
@@ -1,13 +1,13 @@
 val exec :
-  ?switch:Switch.t -> ?stdin:string ->
+  ?stdin:string ->
   ?pp_error_command:(Format.formatter -> unit) ->
-  job:Job.t -> Lwt_process.command ->
+  cancellable:bool -> job:Job.t -> Lwt_process.command ->
   unit Current_term.S.or_error Lwt.t
 
 val check_output :
-  ?switch:Switch.t -> ?cwd:Fpath.t -> ?stdin:string ->
+  ?cwd:Fpath.t -> ?stdin:string ->
   ?pp_error_command:(Format.formatter -> unit) ->
-  job:Job.t -> Lwt_process.command ->
+  cancellable:bool -> job:Job.t -> Lwt_process.command ->
   string Current_term.S.or_error Lwt.t
 
 val with_tmpdir : ?prefix:string -> (Fpath.t -> 'a Lwt.t) -> 'a Lwt.t

--- a/lib/switch.ml
+++ b/lib/switch.ml
@@ -3,35 +3,30 @@
 
 open Lwt.Infix
 
-type reason = unit Current_term.S.or_error
-
-type callback = reason -> unit Lwt.t
+type callback = unit -> unit Lwt.t
 
 type t = {
-  mutable state : [`On of string * callback Stack.t | `Turning_off of reason Lwt.t | `Off of reason];
+  mutable state : [`On of string * callback Stack.t | `Turning_off of unit Lwt.t | `Off];
 }
 
 let pp_reason f x = Current_term.Output.pp (Fmt.unit "()") f (x :> unit Current_term.Output.t)
 
-let turn_off t reason =
+let turn_off t =
   match t.state with
-  | `Off orig ->
-    Log.info (fun f -> f "Switch.turn_off(%a): already off (due to %a)"
-                 pp_reason reason
-                 pp_reason orig);
+  | `Off ->
+    Log.info (fun f -> f "Switch.turn_off: already off");
     Lwt.return_unit
   | `Turning_off thread ->
-    thread >|= fun (_ : reason) ->
-    ()
+    thread
   | `On (_, callbacks) ->
     let th, set_th = Lwt.wait () in
     t.state <- `Turning_off th;
     let rec aux () =
       match Stack.pop callbacks with
-      | fn -> fn reason >>= aux
+      | fn -> fn () >>= aux
       | exception Stack.Empty ->
-        t.state <- `Off reason;
-        Lwt.wakeup set_th reason;
+        t.state <- `Off;
+        Lwt.wakeup set_th ();
         Lwt.return_unit
     in
     aux ()
@@ -40,18 +35,17 @@ let turn_off t reason =
    forgets to turn it off. *)
 let gc t =
   match t.state with
-  | `Off _ | `Turning_off _ -> ()
+  | `Off | `Turning_off _ -> ()
   | `On (label, _) ->
     Log.err (fun f -> f "Switch %S GC'd while still on!" label);
-    Lwt.async (fun () -> turn_off t @@ Error (`Msg "Switch GC'd while still on!"))
+    Lwt.async (fun () -> turn_off t)
 
 let add_hook_or_fail t fn =
   match t.state with
   | `On (_, callbacks) ->
     if Stack.is_empty callbacks then Gc.finalise gc t;
     Stack.push fn callbacks
-  | `Off (Ok ()) -> Fmt.failwith "Switch already off!"
-  | `Off (Error (`Msg msg)) -> Fmt.failwith "Switch already off (%s)!" msg
+  | `Off -> Fmt.failwith "Switch already off!"
   | `Turning_off _ -> Fmt.failwith "Switch is being turned off!"
 
 let add_hook_or_exec t fn =
@@ -60,8 +54,8 @@ let add_hook_or_exec t fn =
     if Stack.is_empty callbacks then Gc.finalise gc t;
     Stack.push fn callbacks;
     Lwt.return_unit
-  | `Off reason ->
-    fn reason
+  | `Off ->
+    fn ()
   | `Turning_off thread ->
     thread >>= fn
 
@@ -74,32 +68,17 @@ let create ~label () = {
   state = `On (label, Stack.create ());
 }
 
-let create_off reason = {
-  state = `Off reason;
+let create_off () = {
+  state = `Off;
 }
 
 let is_on t =
   match t.state with
   | `On _ -> true
-  | `Off _ | `Turning_off _ -> false
+  | `Off | `Turning_off _ -> false
 
 let pp f t =
   match t.state with
   | `On (label, _) -> Fmt.pf f "on(%S)" label
-  | `Off r -> Fmt.pf f "off(%a)" pp_reason r
+  | `Off -> Fmt.pf f "off"
   | `Turning_off _ -> Fmt.string f "turning-off"
-
-let pp_duration f d =
-  let d = Duration.to_f d in
-  if d > 120.0 then Fmt.pf f "%.1f minutes" (d /. 60.)
-  else if d > 2.0 then Fmt.pf f "%.1f seconds" d
-  else Fmt.pf f "%f seconds" d
-
-let add_timeout t duration =
-  (* We could be smarter about this. e.g. cancel the timeout when the switch is turned off or
-     only keep the nearest timeout. *)
-  Lwt.async (fun () ->
-      Lwt_unix.sleep (Duration.to_f duration) >>= fun () ->
-      if is_on t then turn_off t @@ Error (`Msg (Fmt.strf "Timeout (%a)" pp_duration duration))
-      else Lwt.return_unit
-    )

--- a/lib_cache/s.ml
+++ b/lib_cache/s.ml
@@ -38,12 +38,10 @@ module type BUILDER = sig
   (** The result of a build. *)
 
   val build :
-    switch:Current.Switch.t ->
     t -> Current.Job.t -> Key.t ->
     Value.t Current.or_error Lwt.t
-  (** [build ~switch t j k] builds [k].
+  (** [build t j k] builds [k].
       Call [Job.start j] once any required resources have been acquired.
-      If the switch is turned off, the build should be cancelled.
       Log messages can be written to [j]. *)
 
   val pp : Key.t Fmt.t
@@ -67,11 +65,10 @@ module type PUBLISHER = sig
       Usually this is just [Current.Unit]. *)
 
   val publish :
-    switch:Current.Switch.t -> t -> Current.Job.t -> Key.t -> Value.t ->
+    t -> Current.Job.t -> Key.t -> Value.t ->
     Outcome.t Current.or_error Lwt.t
-  (** [publish ~switch t j k v] sets output [k] to value [v].
+  (** [publish t j k v] sets output [k] to value [v].
       Call [Job.start j] once any required resources have been acquired.
-      If the switch is turned off, the operation should be cancelled.
       Log messages can be written to [j]. *)
 
   val pp : (Key.t * Value.t) Fmt.t

--- a/plugins/docker/pull.ml
+++ b/plugins/docker/pull.ml
@@ -17,14 +17,14 @@ module Value = Image
 
 let id = "docker-pull"
 
-let build ~switch No_context job key =
+let build No_context job key =
   Current.Job.start job ~level:Current.Level.Mostly_harmless >>= fun () ->
-  Current.Process.exec ~switch ~job (Key.cmd key) >>= function
+  Current.Process.exec ~cancellable:true ~job (Key.cmd key) >>= function
   | Error _ as e -> Lwt.return e
   | Ok () ->
     let { Key.docker_context; tag } = key in
     let cmd = Cmd.docker ~docker_context ["image"; "inspect"; tag; "-f"; "{{index .RepoDigests 0}}"] in
-    Current.Process.check_output ~job cmd >|= function
+    Current.Process.check_output ~cancellable:false ~job cmd >|= function
     | Error _ as e -> e
     | Ok id ->
       let id = String.trim id in

--- a/plugins/docker/push.ml
+++ b/plugins/docker/push.ml
@@ -33,9 +33,9 @@ module Outcome = Current.String (* [S.repo_id] *)
 let tag_cmd { Key.tag; docker_context } { Value.image } =
   Cmd.docker ~docker_context ["tag"; Image.hash image; tag]
 
-let publish ~switch auth job key value =
+let publish auth job key value =
   Current.Job.start job ~level:Current.Level.Dangerous >>= fun () ->
-  Current.Process.exec ~switch ~job (tag_cmd key value) >>= function
+  Current.Process.exec ~cancellable:true ~job (tag_cmd key value) >>= function
   | Error _ as e -> Lwt.return e
   | Ok () ->
     let { Key.tag; docker_context } = key in
@@ -43,12 +43,12 @@ let publish ~switch auth job key value =
       | None -> Lwt.return (Ok ())
       | Some (user, password) ->
         let cmd = Cmd.login ~docker_context user in
-        Current.Process.exec ~switch ~job ~stdin:password cmd
+        Current.Process.exec ~cancellable:true ~job ~stdin:password cmd
     end >>!= fun () ->
     let cmd = Cmd.docker ~docker_context ["push"; tag] in
-    Current.Process.exec ~switch ~job cmd >>!= fun () ->
+    Current.Process.exec ~cancellable:true ~job cmd >>!= fun () ->
     let cmd = Cmd.docker ~docker_context ["image"; "inspect"; tag; "-f"; "{{index .RepoDigests 0}}"] in
-    Current.Process.check_output ~job cmd >|= Stdlib.Result.map @@ fun id ->
+    Current.Process.check_output ~cancellable:false ~job cmd >|= Stdlib.Result.map @@ fun id ->
     let repo_id = String.trim id in
     Current.Job.log job "Pushed %S -> %S" tag repo_id;
     repo_id

--- a/plugins/docker/run.ml
+++ b/plugins/docker/run.ml
@@ -28,9 +28,9 @@ end
 
 module Value = Current.Unit
 
-let build ~switch No_context job key =
+let build No_context job key =
   Current.Job.start job ~level:Current.Level.Average >>= fun () ->
-  Current.Process.exec ~switch ~job (Key.cmd key)
+  Current.Process.exec ~cancellable:true ~job (Key.cmd key)
 
 let pp = Key.pp
 

--- a/plugins/docker/service.ml
+++ b/plugins/docker/service.ml
@@ -29,9 +29,9 @@ module Outcome = Current.Unit
 let cmd { Key.name; docker_context } { Value.image } =
   Cmd.docker ~docker_context ["service"; "update"; "--image"; Image.hash image; name]
 
-let publish ~switch No_context job key value =
+let publish No_context job key value =
   Current.Job.start job ~level:Current.Level.Dangerous >>= fun () ->
-  Current.Process.exec ~switch ~job (cmd key value)
+  Current.Process.exec ~cancellable:true ~job (cmd key value)
 
 let pp f (key, value) =
   Cmd.pp f (cmd key value)

--- a/plugins/docker/tag.ml
+++ b/plugins/docker/tag.ml
@@ -31,9 +31,9 @@ module Outcome = Current.Unit
 let tag_cmd { Key.tag; docker_context } { Value.image } =
   Cmd.docker ~docker_context ["tag"; Image.hash image; tag]
 
-let publish ~switch No_context job key value =
+let publish No_context job key value =
   Current.Job.start job ~level:Current.Level.Average >>= fun () ->
-  Current.Process.exec ~switch ~job (tag_cmd key value)
+  Current.Process.exec ~cancellable:true ~job (tag_cmd key value)
 
 let pp f (key, value) =
   Cmd.pp f (tag_cmd key value)

--- a/plugins/git/clone.ml
+++ b/plugins/git/clone.ml
@@ -31,17 +31,17 @@ let repo_lock repo =
 
 let id = "git-clone"
 
-let build ~switch No_context job { Key.repo; gref } =
+let build No_context job { Key.repo; gref } =
   Lwt_mutex.with_lock (repo_lock repo) @@ fun () ->
   Current.Job.start job ~level:Current.Level.Mostly_harmless >>= fun () ->
   let local_repo = Cmd.local_copy repo in
   (* Ensure we have a local clone of the repository. *)
   begin
     if Cmd.dir_exists local_repo
-    then Cmd.git_fetch ~switch ~job ~src:repo ~dst:local_repo (Fmt.strf "%s:refs/remotes/origin/%s" gref gref)
-    else Cmd.git_clone ~switch ~job ~src:repo local_repo
+    then Cmd.git_fetch ~cancellable:true ~job ~src:repo ~dst:local_repo (Fmt.strf "%s:refs/remotes/origin/%s" gref gref)
+    else Cmd.git_clone ~cancellable:true ~job ~src:repo local_repo
   end >>!= fun () ->
-  Cmd.git_rev_parse ~switch ~job ~repo:local_repo ("origin/" ^ gref) >>!= fun hash ->
+  Cmd.git_rev_parse ~cancellable:true ~job ~repo:local_repo ("origin/" ^ gref) >>!= fun hash ->
   let id = { Commit_id.repo; gref; hash } in
   Lwt.return @@ Ok { Commit.repo = local_repo; id }
 

--- a/plugins/git/cmd.ml
+++ b/plugins/git/cmd.ml
@@ -15,34 +15,34 @@ let local_copy repo =
   let repos_dir = Current.state_dir "git" in
   Fpath.append repos_dir (Fpath.v (id_of_repo repo))
 
-let git ?switch ~job ?cwd args =
+let git ~cancellable ~job ?cwd args =
   let args =
     match cwd with
     | None -> args
     | Some cwd -> "-C" :: Fpath.to_string cwd :: args
   in
   let cmd = Array.of_list ("git" :: args) in
-  Current.Process.exec ?switch ~job ("", cmd)
+  Current.Process.exec ~cancellable ~job ("", cmd)
 
-let git_clone ~switch ~job ~src dst =
-  git ~switch ~job ["clone"; "--recursive"; "-q"; src; Fpath.to_string dst]
+let git_clone ~cancellable ~job ~src dst =
+  git ~cancellable ~job ["clone"; "--recursive"; "-q"; src; Fpath.to_string dst]
 
-let git_fetch ~switch ~job ~src ~dst gref =
-  git ~switch ~job ~cwd:dst ["fetch"; "-f"; src; gref]
+let git_fetch ~cancellable ~job ~src ~dst gref =
+  git ~cancellable ~job ~cwd:dst ["fetch"; "-f"; src; gref]
 
 let git_reset_hard ~job ~repo hash =
-  git ~job ~cwd:repo ["reset"; "--hard"; hash]
+  git ~cancellable:false ~job ~cwd:repo ["reset"; "--hard"; hash]
 
 let git_remote_set_url ~job ~repo ~remote url =
-  git ~job ~cwd:repo ["remote"; "set-url"; remote; url]
+  git ~cancellable:false ~job ~cwd:repo ["remote"; "set-url"; remote; url]
 
-let git_rev_parse ?switch ~job ~repo x =
+let git_rev_parse ?(cancellable=false) ~job ~repo x =
   let cmd = ["git"; "-C"; Fpath.to_string repo; "rev-parse"; x] in
-  Current.Process.check_output ?switch ~job ("", Array.of_list cmd) >|= Stdlib.Result.map String.trim
+  Current.Process.check_output ~cancellable ~job ("", Array.of_list cmd) >|= Stdlib.Result.map String.trim
 
-let cp_r ~switch ~job ~src ~dst =
+let cp_r ~cancellable ~job ~src ~dst =
   let cmd = [| "cp"; "-a"; "--"; Fpath.to_string src; Fpath.to_string dst |] in
-  Current.Process.exec ~switch ~job ("", cmd)
+  Current.Process.exec ~cancellable ~job ("", cmd)
 
-let git_submodule_update ~switch ~job ~repo =
-  git ~switch ~job ~cwd:repo ["submodule"; "update"; "--recursive"]
+let git_submodule_update ~cancellable ~job ~repo =
+  git ~cancellable ~job ~cwd:repo ["submodule"; "update"; "--recursive"]

--- a/plugins/git/current_git.mli
+++ b/plugins/git/current_git.mli
@@ -40,12 +40,11 @@ val clone : schedule:Current_cache.Schedule.t -> ?gref:string -> string -> Commi
 val fetch : Commit_id.t Current.t -> Commit.t Current.t
 
 val with_checkout :
-  switch:Current.Switch.t ->
   job:Current.Job.t ->
   Commit.t ->
   (Fpath.t -> 'a Current.or_error Lwt.t) ->
   'a Current.or_error Lwt.t
-(** [with_checkout ~switch ~job c fn] clones [c] to a temporary directory and runs [fn tmpdir].
+(** [with_checkout ~job c fn] clones [c] to a temporary directory and runs [fn tmpdir].
     When it returns, the directory is deleted. *)
 
 module Local : sig

--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -435,7 +435,7 @@ module Commit = struct
         context
         Value.pp status
 
-    let publish ~switch:_ t job key status =
+    let publish t job key status =
       Current.Job.start job ~pool ~level:Current.Level.Above_average >>= fun () ->
       let {Key.commit; context} = key in
       let body = `Assoc (("context", `String context) :: Value.json_items status) in

--- a/plugins/slack/post.ml
+++ b/plugins/slack/post.ml
@@ -8,7 +8,7 @@ module Key = Current.String
 module Value = Current.String
 module Outcome = Current.Unit
 
-let publish ~switch:_ t job _key message =
+let publish t job _key message =
   Current.Job.start job ~level:Current.Level.Above_average >>= fun () ->
   let headers = Cohttp.Header.of_list [
       "Content-type", "application/json";

--- a/test/plugins/git/current_git_test.ml
+++ b/test/plugins/git/current_git_test.ml
@@ -44,7 +44,7 @@ module Clone = struct
 
   let pp f key = Fmt.pf f "git clone %S" key.Commit.repo
 
-  let build ~switch:_ No_context job (key : Key.t) =
+  let build No_context job (key : Key.t) =
     Current.Job.start job ~level:Current.Level.Average >>= fun () ->
     let ready, set_ready = Lwt.wait () in
     state := RepoMap.add key.Commit.repo set_ready !state;


### PR DESCRIPTION
Before, we turned off the switch both when cancelling and when finishing the job, but cancelling is only a request. In particular, we shouldn't close the log or release pool resources just because the user has asked us to cancel.

This commit removes the `switch` argument from the cache API. Instead, use `Job.on_cancel` if you want to do something when the job is cancelled. This is slightly clearer and also prevents the user from
turning off the switch themselves.

Add a separate `Job.cancel` operation to request cancellation of a job.